### PR TITLE
Fixing minor JS CSS bug around Wufoo form (Fixes #1)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -128,7 +128,7 @@ a:hover {
 }
 
 section {
-    padding-top:70px;  
+    padding-top:70px;
     padding-bottom:50px;
     min-height:100%;
     min-height:calc(100% - 0);
@@ -146,7 +146,7 @@ section {
         top: 0; left: 0; bottom: 0; right: 0;
     }
 }
-  
+
 #section1, #section3 {
     background-color: rgba(0,0,0,0.7);
     color:#fff;
@@ -176,7 +176,6 @@ section {
 }
 
 #section4 .container {
-    min-height: 800px;
 }
 
 #section5 {
@@ -210,4 +209,8 @@ footer .nav>li>a:hover {
     text-align: center;
     margin-top: 2em;
     color: #aaa;
+}
+
+.wufoo {
+    min-height: 660px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -176,7 +176,7 @@ section {
 }
 
 #section4 .container {
-    height: 100%;
+    min-height: 800px;
 }
 
 #section5 {

--- a/css/styles.css
+++ b/css/styles.css
@@ -210,7 +210,3 @@ footer .nav>li>a:hover {
     margin-top: 2em;
     color: #aaa;
 }
-
-.wufoo {
-    min-height: 660px;
-}

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 
 
 <section class="container-fluid" id="section4">
-    <div class="container wufoo">
+    <div class="container">
         <div class="row">
             <div class="col-md-12">
                 <h1 class="text-center">Contact Us</h1>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     </div>
 </section>
 
-<section class="container-fluid" id="section4">
+<section class="container-fluid" id="section4" class="wufoo">
     <div class="container v-center">
         <div class="row">
             <div class="col-md-12">

--- a/index.html
+++ b/index.html
@@ -127,8 +127,9 @@
     </div>
 </section>
 
-<section class="container-fluid" id="section4" class="wufoo">
-    <div class="container v-center">
+
+<section class="container-fluid" id="section4">
+    <div class="container wufoo">
         <div class="row">
             <div class="col-md-12">
                 <h1 class="text-center">Contact Us</h1>
@@ -144,8 +145,6 @@
                     var s = d.createElement(t), options = {
                         'userName':'northfoundation',
                         'formHash':'z2kzbi61c6wo9l',
-                        'autoResize':true,
-                        'height':'660',
                         'async':true,
                         'host':'wufoo.com',
                         'header':'show',


### PR DESCRIPTION
- There's some clashing CSS the prevented the wufoo form from getting the height it needs. This removes the clashing parts.  
- `autoResize` and `height` aren't accomplishing anything in the current configuration. 
- Tested in Chrome, Firefox, and Safari.
